### PR TITLE
Fix Lambda function accessing S3 object

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ This is a project that has issues with Terraform and a simple AWS Lambda functio
 1. Execute `terraform apply` to create the resources.
 2. Test the Lambda function to make sure it's working as expected.
 
+## Root Cause & Solution
+
+### Root Cause:
+The Lambda function lacked the necessary IAM permissions to read the deployment package from the S3 bucket, causing execution failures.
+
+### Solution:
+Added an IAM policy that grants the Lambda function `s3:GetObject` permissions for the specific S3 object (`lambda_function_payload.zip`) and attached it to the Lambda's IAM role.

--- a/main.tf
+++ b/main.tf
@@ -35,3 +35,27 @@ resource "aws_iam_role" "iam_for_lambda" {
     ]
   })
 }
+
+# add an IAM policy that grants the Lambda function read access (s3:GetObject) to the specific S3 object
+# (lambda_function_payload.zip). Without this, the Lambda function cannot retrieve its deployment package.
+resource "aws_iam_policy" "s3_access_policy" {
+  name        = "s3-access-policy"
+  description = "Allows Lambda to access S3 bucket"
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action   = ["s3:GetObject"],
+        Effect   = "Allow",
+        Resource = "arn:aws:s3:::my-super-cool-bucket/lambda_function_payload.zip"
+      }
+    ]
+  })
+}
+
+# The policy is then attached to the Lambda's IAM role to ensure it has the necessary permissions.
+resource "aws_iam_role_policy_attachment" "lambda_s3_attach" {
+  policy_arn = aws_iam_policy.s3_access_policy.arn
+  role       = aws_iam_role.iam_for_lambda.name
+}
+


### PR DESCRIPTION
The Lambda function lacked the necessary IAM permissions to read the deployment package from the S3 bucket, causing execution failures.

Added an IAM policy that grants the Lambda function s3:GetObject permissions for the specific S3 object (lambda_function_payload.zip) and attached it to the Lambda's IAM role.